### PR TITLE
Add derived enum syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,48 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+ "trybuild",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "proc-macro2"
@@ -29,6 +70,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +128,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "trybuild"
+version = "1.0.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e257d7246e7a9fd015fb0b28b330a8d4142151a33f03e6a497754f4b1f6a8e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ proc-macro = true
 [dependencies]
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,86 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, ItemEnum};
+use std::collections::HashMap;
+use syn::{
+    braced, parse::Parse, parse::ParseStream, parse_macro_input, Ident, ItemEnum, Result, Token,
+    Variant,
+};
+
+mod kw {
+    syn::custom_keyword!(derive);
+    syn::custom_keyword!(from);
+    syn::custom_keyword!(remove);
+}
+
+struct EnumEvolution {
+    base: ItemEnum,
+    derives: Vec<DerivedEnum>,
+}
+
+struct DerivedEnum {
+    name: Ident,
+    source: Ident,
+    removed: Vec<Ident>,
+}
+
+impl Parse for EnumEvolution {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let base: ItemEnum = input.parse()?;
+        let mut derives = Vec::new();
+        while !input.is_empty() {
+            derives.push(input.parse()?);
+        }
+        Ok(EnumEvolution { base, derives })
+    }
+}
+
+impl Parse for DerivedEnum {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<kw::derive>()?;
+        let name: Ident = input.parse()?;
+        input.parse::<kw::from>()?;
+        let source: Ident = input.parse()?;
+        let content; 
+        braced!(content in input);
+        let mut removed = Vec::new();
+        while !content.is_empty() {
+            content.parse::<kw::remove>()?;
+            let ident: Ident = content.parse()?;
+            removed.push(ident);
+            let _ = content.parse::<Token![;]>().ok();
+        }
+        Ok(DerivedEnum { name, source, removed })
+    }
+}
 
 #[proc_macro]
 pub fn enum_evolution(input: TokenStream) -> TokenStream {
-    let item = parse_macro_input!(input as ItemEnum);
-    quote!(#item).into()
+    let EnumEvolution { base, derives } = parse_macro_input!(input as EnumEvolution);
+
+    // Keep track of generated enums so subsequent derives can build on earlier ones.
+    let mut known: HashMap<String, ItemEnum> = HashMap::new();
+    known.insert(base.ident.to_string(), base.clone());
+
+    let mut tokens = quote!(#base);
+
+    for d in derives {
+        if let Some(src) = known.get(&d.source.to_string()) {
+            let removed: std::collections::HashSet<String> =
+                d.removed.iter().map(|i| i.to_string()).collect();
+            let variants: syn::punctuated::Punctuated<Variant, Token![,]> = src
+                .variants
+                .iter()
+                .filter(|v| !removed.contains(&v.ident.to_string()))
+                .cloned()
+                .collect();
+
+            let mut new_enum = src.clone();
+            new_enum.ident = d.name.clone();
+            new_enum.variants = variants;
+            tokens.extend(quote!(#new_enum));
+            known.insert(new_enum.ident.to_string(), new_enum);
+        }
+    }
+
+    tokens.into()
 }

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn removed_variant_is_gone() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/removed_variant_fail.rs");
+}

--- a/tests/derived.rs
+++ b/tests/derived.rs
@@ -1,0 +1,17 @@
+use enum_evolution::enum_evolution;
+
+enum_evolution! {
+    pub enum Foo {
+        Zero,
+        One(usize),
+    }
+
+    derive Bar from Foo {
+        remove Zero
+    }
+}
+
+#[test]
+fn can_use_derived_enum() {
+    let _ = Bar::One(42);
+}

--- a/tests/ui/removed_variant_fail.rs
+++ b/tests/ui/removed_variant_fail.rs
@@ -1,0 +1,16 @@
+use enum_evolution::enum_evolution;
+
+enum_evolution! {
+    enum Foo {
+        Zero,
+        One(usize),
+    }
+
+    derive Bar from Foo {
+        remove Zero
+    }
+}
+
+fn main() {
+    let _ = Bar::Zero;
+}

--- a/tests/ui/removed_variant_fail.stderr
+++ b/tests/ui/removed_variant_fail.stderr
@@ -1,0 +1,11 @@
+error[E0599]: no variant or associated item named `Zero` found for enum `Bar` in the current scope
+  --> tests/ui/removed_variant_fail.rs:15:18
+   |
+4  | /     enum Foo {
+5  | |         Zero,
+6  | |         One(usize),
+7  | |     }
+   | |_____- variant or associated item `Zero` not found for this enum
+...
+15 |       let _ = Bar::Zero;
+   |                    ^^^^ variant or associated item not found in `Bar`


### PR DESCRIPTION
## Summary
- allow `enum_evolution!` to derive new enums with `derive` blocks and removed variants
- add integration tests for deriving enums and compile-time failure when accessing removed variants

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c9c744488324b16085e7e04278b0