### PR TITLE
Support updating and adding enum variants

### DIFF
--- a/tests/update_add.rs
+++ b/tests/update_add.rs
@@ -1,0 +1,19 @@
+use enum_evolution::enum_evolution;
+
+enum_evolution! {
+    pub enum Foo {
+        Zero,
+        One(u32),
+    }
+
+    derive Bar from Foo {
+        update One(u64);
+        add Two(String);
+    }
+}
+
+#[test]
+fn can_use_updated_and_added_variants() {
+    let _ = Bar::One(42u64);
+    let _ = Bar::Two(String::from("hello"));
+}


### PR DESCRIPTION
## Summary
- allow `derive` blocks to `update` existing variants or `add` new ones
- test variant updates and additions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c4cf20279c8324b5483b04487d60db